### PR TITLE
Removing the comment from config

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,4 +1,3 @@
-/* Configuarion File. All the configuation related to export should be mentioned here */
 {
     "mcs": {
         "toolingUrl": "http://unit23587.oracleads.com:7101/internal-tools/",


### PR DESCRIPTION
This is to avoid parse issues.
